### PR TITLE
Fix composer install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This directory contains the PHP source code for the Phalcon Sentry integration.
 ## Installation
 
 ```Bash
-composer install noone-silent/phalcon-sentry
+composer require noone-silent/phalcon-sentry
 ```
 
 ## Usage


### PR DESCRIPTION
Modern composer rejects install commands to add dependencies

```
$ composer install noone-silent/phalcon-sentry
Invalid argument noone-silent/phalcon-sentry.

Use "composer require noone-silent/phalcon-sentry" instead to add packages to your composer.json.
```