### PR TITLE
Refactor: Use ConfigInterface rather concrete Config

### DIFF
--- a/src/Events/AbstractEventHandler.php
+++ b/src/Events/AbstractEventHandler.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phalcon\Sentry\Events;
 
-use Phalcon\Config\Config;
+use Phalcon\Config\ConfigInterface;
 use Phalcon\Di\DiInterface;
 use Phalcon\Di\Injectable;
 use Sentry\State\HubInterface;
@@ -15,18 +15,18 @@ class AbstractEventHandler extends Injectable implements EventHandlerInterface
     /** @var Span[] */
     protected array $spans = [];
 
-    protected Config $config;
+    protected ConfigInterface $config;
 
     protected ?HubInterface $hub;
 
-    public function __construct(DiInterface $container, ?HubInterface $hub, Config $config)
+    public function __construct(DiInterface $container, ?HubInterface $hub, ConfigInterface $config)
     {
         $this->container = $container;
         $this->hub = $hub;
         $this->config = $config;
     }
 
-    public function getConfig(): Config
+    public function getConfig(): ConfigInterface
     {
         return $this->config;
     }

--- a/src/Helpers/Sentry.php
+++ b/src/Helpers/Sentry.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Phalcon\Sentry\Helpers;
 
-use Phalcon\Config\Config;
+use Phalcon\Config\ConfigInterface;
 use Phalcon\Di\AbstractInjectionAware;
 use Phalcon\Di\DiInterface;
 use Phalcon\Mvc\View;
@@ -20,9 +20,9 @@ class Sentry extends AbstractInjectionAware
     public const DEFAULT_HELPER_NAME = 'sentryHelper';
     public const DEFAULT_SENTRY_SCRIPT = 'https://browser.sentry-cdn.com/8.7.0/bundle.tracing.replay.feedback.min.js';
 
-    private static Config $config;
+    private static ConfigInterface $config;
 
-    public function __construct(DiInterface $di, View $view, Config $config)
+    public function __construct(DiInterface $di, View $view, ConfigInterface $config)
     {
         self::$config = $config;
 
@@ -85,7 +85,7 @@ class Sentry extends AbstractInjectionAware
             $viewOptions = self::$config->path('sentry.options', []);
         }
 
-        $viewOptions = $viewOptions instanceof Config ? $viewOptions->toArray() : $viewOptions;
+        $viewOptions = $viewOptions instanceof ConfigInterface ? $viewOptions->toArray() : $viewOptions;
         if (count($viewOptions) === 0) {
             return '';
         }

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -71,7 +71,7 @@ class ServiceProvider implements ServiceProviderInterface
             $di->set('eventsManager', $eventsManager, true);
         }
 
-        /** @var Config $options */
+        /** @var array $options */
         $options = $config->path('sentry.options', [])->toArray();
 
         $default = [];

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -8,8 +8,8 @@ use Phalcon\Cache\AbstractCache;
 use Phalcon\Config\Adapter\Ini;
 use Phalcon\Config\Adapter\Php;
 use Phalcon\Config\Adapter\Yaml;
-use Phalcon\Config\Config;
 use Phalcon\Config\Exception;
+use Phalcon\Config\ConfigInterface;
 use Phalcon\Db\Adapter\Pdo\AbstractPdo;
 use Phalcon\Di\DiInterface;
 use Phalcon\Di\ServiceProviderInterface;
@@ -35,7 +35,7 @@ class ServiceProvider implements ServiceProviderInterface
 {
     protected const SPAN_OP_HTTP_SERVER = 'http.server';
 
-    private string | Config | null $configOrPath;
+    private string | ConfigInterface | null $configOrPath;
 
     private ?DiInterface $container = null;
 
@@ -44,7 +44,7 @@ class ServiceProvider implements ServiceProviderInterface
     /** @var EventHandlerInterface[] */
     private array $handlers = [];
 
-    public function __construct(string | Config | null $configPath = null)
+    public function __construct(string | ConfigInterface | null $configPath = null)
     {
         $this->configOrPath = $configPath;
     }
@@ -63,7 +63,7 @@ class ServiceProvider implements ServiceProviderInterface
         $this->boot($di, $config);
     }
 
-    public function boot(DiInterface $di, Config $config): void
+    public function boot(DiInterface $di, ConfigInterface $config): void
     {
         // The event manager is needed to attach listeners to db and view events.
         if ($di->has('eventsManager') === false) {
@@ -139,9 +139,9 @@ class ServiceProvider implements ServiceProviderInterface
      *
      * @throws Exception
      */
-    protected function mergeConfig(DiInterface $di): Config
+    protected function mergeConfig(DiInterface $di): ConfigInterface
     {
-        if ($this->configOrPath instanceof Config) {
+        if ($this->configOrPath instanceof ConfigInterface) {
             $di->set('phalcon-sentry.config', $this->configOrPath, true);
 
             return $this->configOrPath;
@@ -207,14 +207,14 @@ class ServiceProvider implements ServiceProviderInterface
         $this->hub?->setSpan($this->hub->startTransaction($context));
     }
 
-    private function attach(DiInterface $di, Config $config): void
+    private function attach(DiInterface $di, ConfigInterface $config): void
     {
         $this->attachCache($di, $config);
         $this->attachDb($di, $config);
         $this->attachView($di, $config);
     }
 
-    private function attachCache(DiInterface $di, Config $config): void
+    private function attachCache(DiInterface $di, ConfigInterface $config): void
     {
         if ($config->get('cache', true) === false || $di->has('cache') === false) {
             return;
@@ -252,7 +252,7 @@ class ServiceProvider implements ServiceProviderInterface
         }
     }
 
-    private function attachDb(DiInterface $di, Config $config): void
+    private function attachDb(DiInterface $di, ConfigInterface $config): void
     {
         if ($config->get('db', true) === false || $di->has('db') === false) {
             return;
@@ -277,7 +277,7 @@ class ServiceProvider implements ServiceProviderInterface
         $eventsManager->attach('db', $this->handlers['db']);
     }
 
-    private function attachView(DiInterface $di, Config $config): void
+    private function attachView(DiInterface $di, ConfigInterface $config): void
     {
         if (
             $config->get('view', true) === false ||

--- a/tests/Unit/ServiceProviderTest.php
+++ b/tests/Unit/ServiceProviderTest.php
@@ -6,7 +6,7 @@ namespace Unit;
 
 use Codeception\Test\Unit;
 use Phalcon\Config\Adapter\Ini;
-use Phalcon\Config\Config;
+use Phalcon\Config\ConfigInterface;
 use Phalcon\Di\FactoryDefault;
 use Phalcon\Sentry\ServiceProvider;
 use Throwable;
@@ -32,7 +32,7 @@ class ServiceProviderTest extends Unit
         $config = $di->getShared('phalcon-sentry.config');
 
         // Assert we have a valid config
-        $this->assertInstanceOf(Config::class, $config);
+        $this->assertInstanceOf(ConfigInterface::class, $config);
         // Assert that we merged all values
         $this->assertEquals($config->path('test.value'), 'test');
     }
@@ -55,7 +55,7 @@ class ServiceProviderTest extends Unit
         $config = $di->getShared('phalcon-sentry.config');
 
         // Assert we have a valid config
-        $this->assertInstanceOf(Config::class, $config);
+        $this->assertInstanceOf(ConfigInterface::class, $config);
         // Assert that we merged all values
         $this->assertEquals($config->path('test.value'), 'test');
     }


### PR DESCRIPTION
Methods like ``\Phalcon\Config\Config::merge()` return an  interface rather a specific class:
- https://github.com/phalcon/ide-stubs/blob/14bb6376444345dea0a860f39b8e3eb2481a6c63/src/Config/Config.php#L77
